### PR TITLE
Updated echo with more data and made it work for reverse. Fixed undef on reverse.

### DIFF
--- a/TemperatureCalibration/tour_de_chauffe_v2.scad
+++ b/TemperatureCalibration/tour_de_chauffe_v2.scad
@@ -43,8 +43,11 @@ difference()
         for (i = [1:NumberOfBlocks])
         {
             translate([0,0,BlockSize[2] * (i-1)])
-                block(Reverse ? Labels[NumberOfBlocks-i-1] : Labels[i-1], BlockSize);
-            echo(Labels[i-1]);
+                block(Reverse ? Labels[NumberOfBlocks-i] : Labels[i-1], BlockSize);
+            if (Reverse)
+                echo(Labels[NumberOfBlocks-i], "starts at",BlockSize[2] * (i-1)+TowerBase[2]);
+            else
+                echo(Labels[i-1], "starts at",BlockSize[2] * (i-1)+TowerBase[2]);
         }
         
         //Base

--- a/TemperatureCalibration/tour_de_chauffe_v2.scad
+++ b/TemperatureCalibration/tour_de_chauffe_v2.scad
@@ -42,12 +42,10 @@ difference()
     {
         for (i = [1:NumberOfBlocks])
         {
+            blockIndexer = Reverse ? NumberOfBlocks-i : i-1;
             translate([0,0,BlockSize[2] * (i-1)])
-                block(Reverse ? Labels[NumberOfBlocks-i] : Labels[i-1], BlockSize);
-            if (Reverse)
-                echo(Labels[NumberOfBlocks-i], "starts at",BlockSize[2] * (i-1)+TowerBase[2]);
-            else
-                echo(Labels[i-1], "starts at",BlockSize[2] * (i-1)+TowerBase[2]);
+                block(Labels[blockIndexer], BlockSize);
+            echo(Labels[blockIndexer], "starts at",BlockSize[2] * (i-1)+TowerBase[2]);
         }
         
         //Base


### PR DESCRIPTION
Updated echo to display z offset where each block starts to make it easier to load temperature changes in via a slicer. Fixed echo to work correctly for reversed builds. Removed undef block when reversing order.
